### PR TITLE
removed private use property from JotStylusManager header

### DIFF
--- a/JotTouchSDK.framework/Versions/A/Headers/JotStylusManager.h
+++ b/JotTouchSDK.framework/Versions/A/Headers/JotStylusManager.h
@@ -299,8 +299,6 @@ extern NSString * const JotStylusManagerDiscoveryAttemptedButBluetoothOffNotific
 
 //INTERNAL USE ONLY
 
-@property NSMutableSet *currentTouchesSet;
-
 -(void)touchesBegan:(NSSet *)touches;
 -(void)touchesMoved:(NSSet *)touches;
 -(void)touchesEnded:(NSSet *)touches;


### PR DESCRIPTION
The currentTouchesSet causes build warnings, specifically:

1. JotTouchSDK.framework/Versions/A/Headers/JotStylusManager.h:302:1: No 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed
2. JotTouchSDK.framework/Versions/A/Headers/JotStylusManager.h:302:1: Default property attribute 'assign' not appropriate for non-GC object

removing the property from the public header does the trick, since its unused there anyways